### PR TITLE
fix: Ensure that falsy response bodies are correctly handled

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -368,7 +368,7 @@ function define(nockDefs) {
     // Response is not always JSON as it could be a string or binary data or
     // even an array of binary buffers (e.g. when content is encoded).
     let response
-    if (!nockDef.response) {
+    if (typeof nockDef.response === undefined) {
       response = ''
       // TODO: Rename `responseIsBinary` to `responseIsUtf8Representable`.
     } else if (nockDef.responseIsBinary) {

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -8,6 +8,7 @@ const url = require('url')
 const Interceptor = require('../lib/interceptor')
 const nock = require('..')
 const got = require('./got_client')
+const { define } = require("../lib/scope")
 
 it('scope exposes interceptors', () => {
   const scopes = nock.load(
@@ -133,6 +134,21 @@ describe('`Scope#isDone()`', () => {
     expect(scope.isDone()).to.be.true()
 
     scope.done()
+  })
+})
+
+describe('`define()`', function () {
+  it("accurately sets interceptor response when value is `false`", function () {
+    const [scope] = define([{
+      "scope": "http://www.example.test:80",
+      "method": "GET",
+      "path": "/",
+      "body": "",
+      "status": 200,
+      "response": false,
+    }])
+
+    expect(scope.interceptors[0].body).to.be.false()
   })
 })
 


### PR DESCRIPTION
# Description

The title should be fairly descriptive of what is implemented. Before the PR, if a recorded request returned a body with the value of `false` or `null`, on subsequent usage, it would incorrectly be loaded as an empty string. This small patch ensures the value is accurately replayed.

Note: This was opened up against `main` because no `next` or `beta` branches were found.